### PR TITLE
Update parent pom/Add classpath

### DIFF
--- a/osgi.bundle
+++ b/osgi.bundle
@@ -25,5 +25,11 @@
 
 Bundle-SymbolicName: \
                         ${project.groupId}.${project.artifactId}
+
+Class-Path: \
+                        hk2.jar hk2-core.jar class-model.jar config.jar tiger-types.jar \
+                        bean-validator.jar jtype.jar auto-depends.jar javax.inject.jar \
+                        asm-all-repackaged.jar hk2-api.jar osgi-resource-locator.jar \
+                        javax.inject.jar
 # dependent flashlight package resolved at runtime
 # DynamicImport-Package: org.glassfish.flashlight.provider

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0</version>
+        <version>1.0.5</version>
     </parent>
 
     <groupId>org.glassfish.ha</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
                 <version>${hk2.version}</version>
                 <extensions>true</extensions>
                 <configuration>
+                    <generateOSGiHeaders>true</generateOSGiHeaders>
                     <archive>
                         <!-- Use the manifest.mf produced by maven-bundle-plugin:manifest -->
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
Following two entries are missing from the `MANIFEST.MF` of `3.1.12` release.
```
 `HK2-Class-Path-Id`: org.glassfish.hk2:hk2-core:jar:2.0.5 org.glassfish.
 hk2:class-model:jar:2.0.5 org.glassfish.hk2:config:jar:2.0.5 org.jvne
 t:tiger-types:jar:1.4 org.glassfish.hk2.external:bean-validator:jar:2
 .0.5 com.googlecode.jtype:jtype:jar:0.1.0 org.glassfish.hk2:auto-depe
 nds:jar:2.0.5 org.glassfish.hk2.external:javax.inject:jar:2.0.5 org.g
 lassfish.hk2.external:asm-all-repackaged:jar:2.0.5 org.glassfish.hk2:
 hk2-api:jar:2.0.5 org.glassfish.hk2:osgi-resource-locator:jar:1.0.1 j
 avax.inject:javax.inject:jar:1
```
```
Class-Path: hk2-core.jar class-model.jar config.jar tiger-types.jar be
 an-validator.jar jtype.jar auto-depends.jar javax.inject.jar asm-all-
 repackaged.jar hk2-api.jar osgi-resource-locator.jar javax.inject.jar 
```
Ideally these entries should have got generated as part of standard build, but somehow it is not happening and it is not clear how it was getting generated in earlier releases.

The second entry (`Class-Path`) , is an absolute must as without which class resolution fails at runtime resulting in `NoClassDefFoundError`. 

The role of first entry (`HK2-Class-Path-Id`) is not clear as absence of this doesn't seem to cause any difference.

Refer https://github.com/eclipse-ee4j/glassfish-ha-api/issues/14 and https://github.com/eclipse-ee4j/glassfish/pull/22665 for details.

As a workaround, `Class-Path` entry has been added to `osgi-bundle`. As a result of which, this is present in the `MANIFEST.MF` and thus resolving the issue being encounter.