### PR TITLE
Bump project version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -28,7 +29,7 @@
 
     <groupId>org.glassfish.ha</groupId>
     <artifactId>ha-api</artifactId>
-    <version>3.1.13-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <name>GlassFish High Availability APIs and SPI</name>
 
     <scm>


### PR DESCRIPTION
Due to missed merge for
- #31

and as 3.1.13 is already in Central I propose to bump the version to avoid conflict with next release.